### PR TITLE
TYPE2JOURNAL global variables

### DIFF
--- a/models/invoice.py
+++ b/models/invoice.py
@@ -11,6 +11,13 @@ import openerp.addons.decimal_precision as dp
 import logging
 _logger = logging.getLogger(__name__)
 
+TYPE2JOURNAL = {
+    'out_invoice': 'sale',
+    'in_invoice': 'purchase',
+    'out_refund': 'sale',
+    'in_refund': 'purchase',
+}
+
 class AccountInvoiceLine(models.Model):
     _inherit = 'account.invoice.line'
 


### PR DESCRIPTION
Ésta variable en la linea 220 dá un pequeño error de vez en cuando, lo coloqué como está en account.invoice originalmente, ya que en el módulo account ésto está fuera de la clase en sí misma, por ello el error, hay que definirlo también en éste archivo.